### PR TITLE
Fix file already exists errors when compiling

### DIFF
--- a/u_of_t_scripts/compile_sim.tcl
+++ b/u_of_t_scripts/compile_sim.tcl
@@ -9,4 +9,4 @@ load_package flow
 execute_module -tool map
 execute_module -tool eda
 
-file copy "simulation/modelsim/$quartus(project).vo" "simulation/modelsim/main.vo"
+file copy -force "simulation/modelsim/$quartus(project).vo" "simulation/modelsim/main.vo"


### PR DESCRIPTION
# Context

When you try to compile your code for a second time with `compile_sim.tcl` (e.g. after an edit), you get an error indicating that `main.vo` was already generated and can't be overwritten.

# Solution

This change adds the [`-force`](https://www.tcl.tk/man/tcl8.0/TclCmd/file.htm#M7) flag to the `file copy` command such that previous `main.vo` files can be overwritten.

# Tests completed

I've verified that this works on my system (Windows 10) by running `compile_sim.tcl` with and without the flag and ensuring the results are as expected.

# Further details

The exact error message shown upon compiling a second time is:
```
Error:error copying "simulation/modelsim/lab2.vo" to "simulation/modelsim/main.vo": file already exists
Error:    while executing
Error:"file copy "simulation/modelsim/$quartus(project).vo" "simulation/modelsim/main.vo""
Error:    (file "../../../Software/u_of_t_scripts/compile_sim.tcl" line 12)
```